### PR TITLE
Allow scbulletin to flag depth as fixed

### DIFF
--- a/apps/python/scbulletin-lib.py
+++ b/apps/python/scbulletin-lib.py
@@ -227,7 +227,7 @@ class Bulletin(object):
             txt += "    Depth                %11.3f km" % dep
         else:
             txt += "    Depth                 %7.0f km" % dep
-        if not deperr:
+        if deperr is None:
             txt += "\n"
         elif deperr == 0:
             txt += "   (fixed)\n"


### PR DESCRIPTION
In scbulletin's autoloc3 mode, the intention of the code seems to be that depths with uncertainties of 0 are flagged as fixed. However, this code branch was unreachable, since the previous check (`if not deperr`) would always immediately skip the depth uncertainty output.

The same bug is present in seiscomp3's scbulletin - should I submit a duplicate PR there?