### PR TITLE
scqc latency equation

### DIFF
--- a/apps/processing/scqc/descriptions/scqc.rst
+++ b/apps/processing/scqc/descriptions/scqc.rst
@@ -68,7 +68,7 @@ latency [s]
 
  .. math::
 
-   latency = t_{arr2} - t_{arr1}.
+   latency = t_{22} - t_{21}.
 
  For constant and low delays, latency is approximately the mean record length.
 


### PR DESCRIPTION
Hello,

The doc for scqc the text suggests that latency is a function of end-time, while the equation suggests it's rather reception time...

https://www.seiscomp.de/doc/apps/scqc.html