### PR TITLE
[scxmldump] adding support for journaling

### DIFF
--- a/apps/tools/scxmldump/descriptions/scxmldump.rst
+++ b/apps/tools/scxmldump/descriptions/scxmldump.rst
@@ -21,11 +21,11 @@ Export configuration
 
    scxmldump -fC -o config.xml -d mysql://sysop:sysop@localhost/seiscomp
 
-Export full event data
+Export full event data incl. the relevant journal entries
 
 .. code-block:: sh
 
-   scxmldump -fPAMF -E test2012abcd -o test2012abcd.xml \
+   scxmldump -fPAMFJ -E test2012abcd -o test2012abcd.xml \
              -d mysql://sysop:sysop@localhost/seiscomp
 
 
@@ -53,3 +53,11 @@ Copy event
    scxmldump -fPAMF -E test2012abcd \
              -d mysql://sysop:sysop@localhost/seiscomp | \
    scdb -i - -d mysql://sysop:sysop@archive-db/seiscomp
+
+
+Export the entire journal:
+
+.. code-block:: sh
+
+   scxmldump -fJ -o journal.xml \
+             -d mysql://sysop:sysop@localhost/seiscomp

--- a/apps/tools/scxmldump/descriptions/scxmldump.xml
+++ b/apps/tools/scxmldump/descriptions/scxmldump.xml
@@ -74,6 +74,11 @@
 						Dump the configuration database.
 					</description>
 				</option>
+				<option flag="J" long-flag="journal">
+					<description>
+						Dump the journal. In combination with -E only corresponding journal entries are included.
+					</description>
+				</option>
 				<option flag="R" long-flag="routing">
 					<description>
 						Dump the routing database.


### PR DESCRIPTION
This PR adds support for dumping the journal to XML using scxmldump.

It may be invoked stand-alone to dump the entire journal or in the context of an event or several events to dump only the journal entries relevant to the selected event(s).