### PR TITLE
[scautoloc] Call locator init method

### DIFF
--- a/apps/processing/scautoloc/app.cpp
+++ b/apps/processing/scautoloc/app.cpp
@@ -502,7 +502,7 @@ bool App::init() {
 		}
 	}
 	
-	return Autoloc3::init();
+	return Autoloc3::init(configuration());
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/apps/processing/scautoloc/autoloc.cpp
+++ b/apps/processing/scautoloc/autoloc.cpp
@@ -83,9 +83,9 @@ Autoloc3::~Autoloc3()
 }
 
 
-bool Autoloc3::init()
+bool Autoloc3::init(const Seiscomp::Config::Config &config)
 {
-        if ( ! _relocator.init())
+        if ( ! _relocator.init(config))
                 return false;
 
 	_relocator.setMinimumDepth(_config.minimumDepth);
@@ -97,7 +97,7 @@ bool Autoloc3::init()
 		    return false;
 	}
 
-        if ( ! _nucleator.init())
+        if ( ! _nucleator.init(config))
                 return false;
 
 	SEISCOMP_DEBUG("Setting configured locator profile: %s", _config.locatorProfile.c_str());

--- a/apps/processing/scautoloc/autoloc.h
+++ b/apps/processing/scautoloc/autoloc.h
@@ -248,7 +248,7 @@ class Autoloc3 {
 		bool setStation(Station *);
 		void setLocatorProfile(const std::string &);
 
-		bool init();
+		bool init(const Seiscomp::Config::Config &config);
 
 	public:
 		// Feed a Pick and try to get something out of it.

--- a/apps/processing/scautoloc/locator.cpp
+++ b/apps/processing/scautoloc/locator.cpp
@@ -63,7 +63,7 @@ Locator::Locator()
 {
 }
 
-bool Locator::init()
+bool Locator::init(const Seiscomp::Config::Config &config)
 {
 	const std::string locator = "LOCSAT";
 	_sc3locator =
@@ -71,6 +71,9 @@ bool Locator::init()
 	if (!_sc3locator) {
 		SEISCOMP_ERROR_S("Could not create "+locator+" instance");
 		exit(-1);
+	}
+	if ( !_sc3locator->init(config) ) {
+		return false;
 	}
 	_sc3locator->useFixedDepth(false);
 	_locatorCallCounter = 0;

--- a/apps/processing/scautoloc/locator.h
+++ b/apps/processing/scautoloc/locator.h
@@ -43,7 +43,7 @@ class Locator {
 		Locator();
 		~Locator();
 
-		bool init();
+		bool init(const Seiscomp::Config::Config &config);
 		void setStation(const Station *station);
 		void setMinimumDepth(double);
 

--- a/apps/processing/scautoloc/nucleator.cpp
+++ b/apps/processing/scautoloc/nucleator.cpp
@@ -63,9 +63,9 @@ GridSearch::GridSearch()
 	_abort = false;
 }
 
-bool GridSearch::init()
+bool GridSearch::init(const Seiscomp::Config::Config &config)
 {
-	if ( ! _relocator.init())
+	if ( ! _relocator.init(config))
 		return false;
 	return true;
 }

--- a/apps/processing/scautoloc/nucleator.h
+++ b/apps/processing/scautoloc/nucleator.h
@@ -34,7 +34,7 @@ namespace Autoloc {
 class Nucleator
 {
 	public:
-		virtual bool init() = 0;
+		virtual bool init(const Seiscomp::Config::Config &config) = 0;
 		virtual void setStation(const Station *station);
 	public:
 		virtual bool feed(const Pick *pick) = 0;
@@ -70,7 +70,7 @@ class GridSearch : public Nucleator
 {
 	public:
 		GridSearch();
-		virtual bool init();
+		virtual bool init(const Seiscomp::Config::Config &config);
 
 	public:
 		// Configuration parameters controlling the behaviour of the Nucleator


### PR DESCRIPTION
This includes to forward the application config object through all components to the locator instance.

Because LOCSAT has own defined parameters which can be set in `global.cfg` or even `scautoloc.cfg` fully transparent to the application itself it is required to call the init method. This PR does exactly that.