### PR TITLE
Correct mag processor lookup when estimating Mw

### DIFF
--- a/apps/processing/scmag/magtool.cpp
+++ b/apps/processing/scmag/magtool.cpp
@@ -928,7 +928,11 @@ bool MagTool::computeNetworkMagnitude(DataModel::Origin *origin, const std::stri
 		}
 	}
 
-	ProcessorList::iterator it = _processors.find(mtype);
+	// Find the magnitude processor for this mag type
+	ProcessorList::iterator it;
+	for ( it = _processors.begin(); it != _processors.end(); it++ ) {
+		if ( it->second->type() == mtype ) break;
+	}
 	if ( it == _processors.end() ) return false;
 
 	if ( staCount ) {


### PR DESCRIPTION
The collection of magnitude processors available to MagTool is stored in the multimap _processors, which maps amplitudeType => processor. However, when we estimate Mw at the end of the method `computeNetworkMagnitude`, we were getting a magnitude processor by indexing `_processors` using a *magnitude* type, not an amplitude type. In the common case where these coincide, this works; but it means that when a custom magnitude plugin used an existing amplitude type then it was not having the estimated Mw network magnitudes produced.

This PR rectifies this issue by replacing the `_processors.find(mtype)` with a loop looking for the correct magnitude type.