### PR TITLE
Fix fdsnws crash when processing <remark>

### DIFF
--- a/apps/tools/inventory/fdsnxml2inv/convert2fdsnxml.cpp
+++ b/apps/tools/inventory/fdsnxml2inv/convert2fdsnxml.cpp
@@ -1028,7 +1028,7 @@ bool Convert2FDSNStaXML::process(FDSNXML::Station *sx_sta,
 			try {
 				const DataModel::Blob &blob = sensor->remark();
 				rapidjson::Document json;
-				if ( !json.Parse(blob.content().c_str()).HasParseError() ) {
+				if ( !json.Parse(blob.content().c_str()).HasParseError() && json.IsObject() ) {
 					rapidjson::Value::ConstMemberIterator jit = json.FindMember("unit");
 					if ( jit != json.MemberEnd() && jit->value.IsString() )
 						inputUnits.setDescription(jit->value.GetString());
@@ -1390,7 +1390,7 @@ bool Convert2FDSNStaXML::process(FDSNXML::Channel *sx_chan,
 	try {
 		const DataModel::Blob &blob = sensor->remark();
 		rapidjson::Document json;
-		if ( !json.Parse(blob.content().c_str()).HasParseError() ) {
+		if ( !json.Parse(blob.content().c_str()).HasParseError() && json.IsObject() ) {
 			rapidjson::Value::ConstMemberIterator jit = json.FindMember("unit");
 			if ( jit != json.MemberEnd() && jit->value.IsString() )
 				unitDescription = jit->value.GetString();


### PR DESCRIPTION
When a sensor's `<remark>` element contains valid JSON that is not an object, the call to `FindMember` in convert2fdsnxml.cpp results in a hard crash.  (Sadly the `try/catch` doesn't catch rapidjson's assertions).

For example, we experienced this with a sensor whose remark was a numeric code: `<remark>132</remark>`.

Simple fix is to not only check that parsing succeeded, but also that the result was an object.