### PR TITLE
[scalert] allow to configure min num of phases threshold for pick script

### DIFF
--- a/apps/python/descriptions/scalert.xml
+++ b/apps/python/descriptions/scalert.xml
@@ -85,6 +85,18 @@
 					received pick has one of the value(s).
 					</description>
 				</parameter>
+				<parameter name="phaseNumber" type="int" default="1">
+					<description>
+					Start the pick script only when a minimum number of phases
+					'phaseNumber' is received within 'phaseInterval'.
+					</description>
+				</parameter>
+				<parameter name="phaseInterval" type="int" default="1" unit='s'>
+					<description>
+					Start the pick script only when a minimum number of phases
+					'phaseNumber' is received within 'phaseInterval'.
+					</description> 
+				</parameter>  
 			</group>
 		</configuration>
 		<command-line>


### PR DESCRIPTION
This PR adds two parameter options to scalert: `phaseNumber` and `phaseInterval`. Those allow to start the pick script only when a minimum number of phases `phaseNumber` is received within `phaseInterval`.

I find this option particularly useful, because calling a script for every pick is way too noisy and it is difficult to make use of it. However allowing to configure 3, 4 or even 2 phases before calling the script enables to be alerted of probably real but small events (and for big ones as well).