### PR TITLE
[scart] Allow to rename net, sta, loc, ch codes in import mode

### DIFF
--- a/apps/python/descriptions/scart.xml
+++ b/apps/python/descriptions/scart.xml
@@ -162,6 +162,20 @@
 					Import mode: print all accessed files to stdout after import.
 					</description>
 				</option>
+				<option flag="" long-flag="rename" argument="rule">
+					<description>
+					Rename stream data according to the provided rule(s).
+					A rule is "[match-stream:]rename-stream" and match-stream
+					is optional. match-stream and rename-stream are in the 
+					"NET.STA.LOC.CHA" format. match-stream supports special
+					charactes "?" "*" "|" "(" ")". rename-stream supports the
+					special character "-" that can be used in place of NET, STA,
+					LOC, CHA codes with the meaning of not renaming those. 
+					"-" can also be used as the last character in CHA code.
+					Multiple rules can be provided as a comma separated list
+					or by providing multiple --rename options. 
+					</description>
+				</option>
 			</group>
 		</command-line>
 	</module>


### PR DESCRIPTION
I found myself in several situations where I needed to rename network, station, location or channel codes when importing miniseed data into a local SDS archive. So I am here proposing this change to scart in case it is of any interest for the general community.

```
Add cmd options:
 --rename-net arg  Import mode: rename the data network code to arg
 --rename-sta arg  Import mode: rename the data station code to arg
 --rename-loc arg  Import mode: rename the data location code to arg
 --rename-cha arg  Import mode: rename the data channel code to arg,
                                  which can be 3 or 2 characters long
```