### PR TITLE
[scart] Unify -t -n -c --list --sncl options for Dump and Import mode

### DIFF
--- a/apps/python/descriptions/scart.rst
+++ b/apps/python/descriptions/scart.rst
@@ -53,7 +53,7 @@ Examples
 .. hint::
 
    The usage of wildcards in place of network, station, location or channel code
-   is allowed in many options (-n,-c,-l,-nslc) and follows these rules:
+   is allowed in many options (-n, -c, -l, --list, --nslc) and follows these rules:
 
    * Import mode: the wildcards are passed to the :ref:`global_recordstream` interface,
      that interprets them. Normally both "*" and "?" are supported by RecordStreams.
@@ -68,9 +68,9 @@ Examples
 
       scart -dsvE -t '[start-time]~[end-time]' [SDS archive] > [file.mseed]
       scart -dsvE -t '[start-time]~[end-time]' > file.mseed
-      scart -dsvE -t '[start-time]~[end-time]' -n 'NET1,NET2' > file.mseed
-      scart -dsvE -t '[start-time]~[end-time]' -n 'NET' -c '(E,H)H(1,2,3)' > file.mseed
-      scart -dsvE -t '[start-time]~[end-time]' -n 'N1.S1.L1.C1,N2.S2.L2.C2' > file.mseed
+      scart -dsvE -t '[start-time]~[end-time]' -n '[NET1],[NET2]' > file.mseed
+      scart -dsvE -t '[start-time]~[end-time]' -n '[NET]' -c '(E,H)H(1,2,3)' > file.mseed
+      scart -dsvE -t '[start-time]~[end-time]' -n '[N1.S1.L1.C1],[N2.S2.L2.C2]' > file.mseed
       scart -dsvE -t '[start-time]~[end-time]' --nslc list.file > file.mseed
       scart -dsvE -t --list list.file > file.mseed
 
@@ -87,19 +87,19 @@ Examples
       scart -I [file.mseed] [SDS archive]
       scart -I [file.mseed] --with-filecheck [SDS archive]
 
-#. Collect data using the :ref:`global_recordstream` interface e.g. (FDSNWS server)
+#. Collect data using the :ref:`global_recordstream` interface (e.g. FDSNWS server)
    and write to a miniSEED file or import it into a local :term:`SDS` archive. The
-   data streams and the time spans can be defined in several ways. The list of option
-   ``list`` can be generated e.g. by :ref:`scevtstreams`.
+   data streams and the time spans can be defined in several ways. The data streams
+   (::option:`list`) can be automatically generated, e.g., by :ref:`scevtstreams`.
 
    .. code-block:: sh
 
       scart -I fdsnws://[server]:80 --list list.file [SDS archive]
       scart -I fdsnws://[server]:80 --list list.file --stdout > file.mseed
       scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' --nslc list.file [SDS archive]
-      scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' -n 'NET1,NET2' [SDS archive]
-      scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' -n 'NET' -c 'EH?' [SDS archive]
-      scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' -n 'N1.S1.L1.C1,N2.S2.L2.C2' [SDS archive]
+      scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' -n '[NET1],[NET2]' [SDS archive]
+      scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' -n '[NET]' -c 'EH?' [SDS archive]
+      scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' -n '[N1.S1.L1.C1],[N2.S2.L2.C2]' [SDS archive]
 
    It is possible to achieve the same result of the dump mode using a 
    combination of the input mode and the :ref:`scmssort` command, which allows
@@ -108,11 +108,11 @@ Examples
 
    .. code-block:: sh
 
-      scart -I recordStream --list list.file --stdout | \
+      scart -I [record-stream] --list list.file --stdout | \
         scmssort -u -E -v > file.mseed
 
 #. Check all files of an SDS archive or other directory structure for
-   miniSEED files for out-of-order records:
+   miniSEED files with out-of-order records:
 
    .. code-block:: sh
 

--- a/apps/python/descriptions/scart.xml
+++ b/apps/python/descriptions/scart.xml
@@ -55,9 +55,9 @@
 			<group name="Output">
 				<option flag="c" argument="channels">
 					<description>
-					Specify the channel filter for the dumped streams as regular
-					expression. Default: (B|S|M|H)(L|H)(Z|N|E). To dump only
-					BHZ, BHN and BHE streams use BH(Z|N|E).
+					Channel filter to be applied to the streams selected by -n option.
+					Default for Dump: "(B|E|H|M|S)(D|H|L|N)(E|F|N|Z|1|2|3)"
+					Default for Import: "*" 
 					</description>
 				</option>
 				<option flag="E">
@@ -106,7 +106,11 @@
 				</option>
 				<option flag="n" argument="networks">
 					<description>
-					List of network codes to dump (comma separated). Default: *.
+					Stream list (comma separated) stream1,stream2,streamX,
+					where each stream can be NET or NET.STA or NET.STA.LOC
+					or NET.STA.LOC.CHA. if CHA is not provided it defaults
+					to the value of -c option. if NET, STA, LOC are not provided
+					they default to "*". Default: "*"
 					</description>
 				</option>
 				<option flag="s" long-flag="sort">

--- a/apps/python/descriptions/scart.xml
+++ b/apps/python/descriptions/scart.xml
@@ -67,7 +67,7 @@
 				</option>
 				<option long-flag="files" argument="count">
 					<description>
-					Specify the number of file handles to cache. Default: 100.
+					Dump mode: specify the number of file handles to cache. Default: 100.
 					</description>
 				</option>
 				<option flag="l" long-flag="list" argument="file">
@@ -99,7 +99,7 @@
 				</option>
 				<option flag="m" long-flag="modify">
 					<description>
-					Modify the record time for real time playback when in export mode.
+					Dump mode: modify the record time for real time playback.
 					The first record time is NOW. The relative time of successive records
 					to the first one are kept.
 					</description>
@@ -115,21 +115,21 @@
 				</option>
 				<option flag="s" long-flag="sort">
 					<description>
-					Sort records by [start-]time. To sort records by their endtime use -E.
+					Dump mode: sort records by [start-]time. To sort records by their
+					endtime use -E.
 					</description>
 				</option>
 				<option long-flag="speed">
 					<description>
-					Specify the speed to dump the records. A value of 0 means no delay
-					otherwise speed is a multiplier of the real time difference between
-					the records. When feeding the records directly into the replay pipe
-					a value of 1 (real time) is recommended.
+					Dump mode: specify the speed to dump the records. A value of 0 means
+					no delay otherwise speed is a multiplier of the real time difference
+					between the records. When feeding the records directly into the replay
+					pipe a value of 1 (real time) is recommended.
 					</description>
 				</option>
 				<option long-flag="stdout">
 					<description>
-					Write to stdout if import mode is used instead of creating a
-					SDS archive.
+					Import mode: write to stdout instead of creating a SDS archive.
 					</description>
 				</option>
 				<option long-flag="print-streams">
@@ -155,13 +155,13 @@
 				</option>
 				<option flag="" long-flag="with-filecheck">
 					<description>
-					Check all accessed files after import. Unsorted or
-					unreadable files are reported to stderr.
+					Import mode: check all accessed files. Unsorted or unreadable
+					files are reported to stderr.
 					</description>
 				</option>
 				<option flag="" long-flag="with-filename">
 					<description>
-					Print all accessed files to stdout after import.
+					Import mode: print all accessed files to stdout after import.
 					</description>
 				</option>
 			</group>

--- a/apps/python/descriptions/scart.xml
+++ b/apps/python/descriptions/scart.xml
@@ -55,14 +55,14 @@
 			<group name="Output">
 				<option flag="c" argument="channels">
 					<description>
-					Channel filter to be applied to the streams selected by -n option.
+					Channel filter to be applied to the data streams.
 					Default for Dump: "(B|E|H|M|S)(D|H|L|N)(E|F|N|Z|1|2|3)"
 					Default for Import: "*" 
 					</description>
 				</option>
 				<option flag="E">
 					<description>
-					Sort records according to their end time. Default: start time.
+					Dump mode: sort records according to their end time. Default: start time.
 					</description>
 				</option>
 				<option long-flag="files" argument="count">
@@ -106,11 +106,9 @@
 				</option>
 				<option flag="n" argument="networks">
 					<description>
-					Stream list (comma separated) stream1,stream2,streamX,
-					where each stream can be NET or NET.STA or NET.STA.LOC
-					or NET.STA.LOC.CHA. if CHA is not provided it defaults
-					to the value of -c option. if NET, STA, LOC are not provided
-					they default to "*". Default: "*"
+					Data stream selection as a comma separated list "stream1,stream2,streamX"
+					where each stream can be NET or NET.STA or NET.STA.LOC or NET.STA.LOC.CHA.
+					If CHA is omitted, it defaults to the value of -c option. Default: "*"
 					</description>
 				</option>
 				<option flag="s" long-flag="sort">

--- a/apps/python/scart.py
+++ b/apps/python/scart.py
@@ -749,14 +749,15 @@ Output:
                     Default for Dump: "(B|E|H|M|S)(D|H|L|N)(E|F|N|Z|1|2|3)"
                     Default for Import: "*"
   -E                Sort according to record end time; default is start time
-  --files arg       Specify the file handles to cache; default: 100
+  --files arg       Dump mode: specify the file handles to cache; default: 100
   -l, --list arg    Use a stream list file instead of defined networks and
                     channels (-n and -c are ignored). The list can be generated
                     from events by scevtstreams. One line per stream
                     Line format: starttime;endtime;streamID
                         2007-03-28 15:48;2007-03-28 16:18;GE.LAST.*.*
                         2007-03-28 15:48;2007-03-28 16:18;GE.PMBI..BH?
-  -m, --modify      Modify the record time for realtime playback when dumping.
+  -m, --modify      Dump mode: modify the record time for realtime playback when
+                    dumping.
   -n arg            Stream list (comma separated) stream1,stream2,streamX
                     where each stream can be NET or NET.STA or NET.STA.LOC
                     or NET.STA.LOC.CHA, if CHA is not provided it defaults
@@ -764,20 +765,19 @@ Output:
   --nslc arg        Use a stream list file for filtering the data by the given
                     streams. For dump mode only! One line per stream.
                     Format: NET.STA.LOC.CHA
-  -s, --sort        Sort records.
-  --speed arg       Specify the speed to dump the records. A value of 0 means
-                    no delay. Otherwise speed is a multiplier of the real time
-                    difference between the records.
-  --stdout          Writes to stdout if import mode is used instead
-                    of creating a SDS archive.
+  -s, --sort        Dump mode: sort records.
+  --speed arg       Dump mode: specify the speed to dump the records. A value
+                    of 0 means no delay. Otherwise speed is a multiplier of
+                    the real time difference between the records.
+  --stdout          Import mode: writes to stdout instead of creating a SDS archive.
   --print-streams   Print stream information only and exit. Works in import, dump and
                     check mode. Output: NET.STA.LOC.CHA StartTime EndTime.
   -t t1~t2          Specify time window (as one properly quoted string)
                     times are of course UTC and separated by a tilde '~' .
   --test            Test only, no record output.
-  --with-filecheck  Check all accessed files after import. Unsorted or
-                    unreadable files are reported to stderr.
-  --with-filename   Print all accessed files to stdout after import.
+  --with-filecheck  Import mode: check all accessed files after import. Unsorted
+                    or unreadable files are reported to stderr.
+  --with-filename   Import mode: print all accessed files to stdout after import.
 
 Examples:
 Read from /archive, create a miniSEED file where records are sorted by end time

--- a/apps/python/scart.py
+++ b/apps/python/scart.py
@@ -724,10 +724,15 @@ def readStreamTimeList(listFile):
 
 usage_info = """
 Usage:
-  scart [options] [archive]
+  scart -I [RecordStream] [options] [archive]
+  scart -I [RecordStream] [options] --stdout
+  scart -d [options] [archive]
+  scart --check [options] [archive]
 
 Import miniSEED waveforms or dump records from an SDS structure, sort them,
 modify the time and replay them. Also check files and archives.
+For Import and Dump mode the data streams can be selected in three ways
+using the combinations of options: -n -c -t  or --nslc -t or --list
 
 Verbosity:
   -h, --help       Display this help message.
@@ -744,27 +749,29 @@ Mode:
                    Default: file://- (stdin)
 
 Output:
-  -c arg            Channel filter to be applied to the streams selected by
-                    -n option.
+  -c arg            Channel filter to be applied to the data streams.
                     Default for Dump: "(B|E|H|M|S)(D|H|L|N)(E|F|N|Z|1|2|3)"
                     Default for Import: "*"
-  -E                Sort according to record end time; default is start time
+  -E                Dump mode: Sort according to record end time; default is
+                    start time
   --files arg       Dump mode: specify the file handles to cache; default: 100
-  -l, --list arg    Use a stream list file instead of defined networks and
-                    channels (-n and -c are ignored). The list can be generated
-                    from events by scevtstreams. One line per stream
+  -l, --list arg    Use a stream list file instead of defined networks, channels
+                    and time window (-n -c and -t are ignored). The list can be
+                    generated from events by scevtstreams. One line per stream
                     Line format: starttime;endtime;streamID
                         2007-03-28 15:48;2007-03-28 16:18;GE.LAST.*.*
                         2007-03-28 15:48;2007-03-28 16:18;GE.PMBI..BH?
-  -m, --modify      Dump mode: modify the record time for realtime playback when
-                    dumping.
-  -n arg            Stream list (comma separated) stream1,stream2,streamX
-                    where each stream can be NET or NET.STA or NET.STA.LOC
-                    or NET.STA.LOC.CHA, if CHA is not provided it defaults
-                    to the value of -c option.  Default: "*"
-  --nslc arg        Use a stream list file for filtering the data by the given
-                    streams. For dump mode only! One line per stream.
-                    Format: NET.STA.LOC.CHA
+  -m, --modify      Dump mode: modify the record time for real time playback
+                    when dumping.
+  -n arg            Data stream selection as a comma separated list
+                    "stream1,stream2,streamX" where each stream can be NET or
+                    NET.STA or NET.STA.LOC or NET.STA.LOC.CHA. If CHA is
+                    omitted, it defaults to the value of -c option.
+                    Default: "*"
+  --nslc arg        Use a stream list file instead of defined networks and
+                    channels (-n and -c are ignored) for filtering the data by
+                    the given streams. Use in combination with -t.
+                    One line per stream, line format: NET.STA.LOC.CHA
   -s, --sort        Dump mode: sort records.
   --speed arg       Dump mode: specify the speed to dump the records. A value
                     of 0 means no delay. Otherwise speed is a multiplier of
@@ -772,8 +779,9 @@ Output:
   --stdout          Import mode: writes to stdout instead of creating a SDS archive.
   --print-streams   Print stream information only and exit. Works in import, dump and
                     check mode. Output: NET.STA.LOC.CHA StartTime EndTime.
-  -t t1~t2          Specify time window (as one properly quoted string)
-                    times are of course UTC and separated by a tilde '~' .
+  -t t1~t2          UTC time window filter to be applied to the data streams
+                    in the format: "StartTime~EndTime"
+                    e.g. "2022-12-20 12:00:00~2022-12-23 14:00:10"
   --test            Test only, no record output.
   --with-filecheck  Import mode: check all accessed files after import. Unsorted
                     or unreadable files are reported to stderr.


### PR DESCRIPTION
These changes were originally part of #52 but it would be better to discuss this change in a separate PR since these are independent from #52 

This PR unifies the usage of -t -n -c -l -sncl options: they can now be used for both Dump and Import mode and makes life easier to the user.

With the new commit it is now possible to perform the following:

Import:
```
scart -I fdsnws://[server]:80 --list list.file [SDS archive]
scart -I fdsnws://[server]:80 --list list.file --stdout > file.mseed
scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' \
      --nslc list.file [SDS archive]
scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' \
      -n 'NET1,NET2' [SDS archive]
scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' \
      -n 'NET' -c 'EH?' [SDS archive]
scart -I fdsnws://[server]:80 -t '[start-time]~[end-time]' \
      -n 'N1.S1.L1.C1,N2.S2.L2.C2' [SDS archive]
```

Dump:
```
scart -dsvE -t '[start-time]~[end-time]' [SDS archive] > [file.mseed]
scart -dsvE -t '[start-time]~[end-time]' > file.mseed
scart -dsvE -t '[start-time]~[end-time]' -n 'NET1,NET2' > file.mseed
scart -dsvE -t '[start-time]~[end-time]' -n 'NET' -c '(E,H)H(1,2,3)' > file.mseed
scart -dsvE -t '[start-time]~[end-time]' -n 'N1.S1.L1.C1,N2.S2.L2.C2' > file.mseed
scart -dsvE -t '[start-time]~[end-time]' --nslc list.file > file.mseed
scart -dsvE -t --list list.file > file.mseed
```