### PR TITLE
[scmag] connection.minimumArrivalWeight does not work

### DIFF
--- a/apps/processing/scmag/descriptions/scmag.xml
+++ b/apps/processing/scmag/descriptions/scmag.xml
@@ -10,6 +10,12 @@
 				station magnitudes.
 				</description>
 			</parameter>
+			<parameter name="minimumArrivalWeight" type="double" default="0.5">
+				<description>
+				The minimum weight of an arrival for an associated amplitude
+				to be used for calculating a magnitude.
+				</description>
+			</parameter>
 			<group name="magnitudes">
 				<description>
 				General parameters for computing magnitudes. Others are configured
@@ -39,12 +45,6 @@
 					<description>
 					Interval between 2 sending processes. The interval controls
 					how often information is updated.
-					</description>
-				</parameter>
-				<parameter name="minimumArrivalWeight" type="double" default="0.5">
-					<description>
-					The minimum weight of an arrival for an associated amplitude
-					to be used for calculating a magnitude.
 					</description>
 				</parameter>
 			</group>


### PR DESCRIPTION
The parameter `connection.minimumArrivalWeight` is not read from the configuration file and it defaults to 0.5

![image](https://github.com/SeisComP/main/assets/15273575/4f16ff34-66e0-406a-afc4-8f46d75de567)

This bug has been there since forever, it looks like not many users need this configuration option ;)