### PR TITLE
[scdbstrip] do not delete anything by default

### DIFF
--- a/apps/python/scdbstrip.py
+++ b/apps/python/scdbstrip.py
@@ -572,7 +572,9 @@ Remove all waveform QC paramters older than 30 days but do not effect event para
                 and self._hoursToKeep is None
                 and self._minutesToKeep is None
             ):
-                self._daysToKeep = 30
+                error.write("ERROR: at least one of datetime, days, hours,"
+                            " minutes should be provided\n")
+                return False
 
             return True
 


### PR DESCRIPTION
Defaulting to delete everything older than 30 days is a very dangerous.

It is quite common for a user to run a command without arguments and expecting in output the syntax of the command. In the case of scdbstrip this would delete data from the database and I don't believe this is a good default.