### PR TITLE
Include created events in output without modified date using --modified-after

### DIFF
--- a/apps/python/scevtls.py
+++ b/apps/python/scevtls.py
@@ -58,7 +58,10 @@ def readXML(self):
                 if evt.creationInfo().modificationTime() < self._modifiedAfterTime:
                     continue
             except ValueError:
-                if evt.creationInfo().creationTime() < self._modifiedAfterTime:
+                try:
+                    if evt.creationInfo().creationTime() < self._modifiedAfterTime:
+                        continue
+                except ValueError:
                     continue
 
         prefOrgID = evt.preferredOriginID()
@@ -269,7 +272,10 @@ Print IDs of all events in XML file
                     if evt.creationInfo().modificationTime() < self._modifiedAfterTime:
                         continue
                 except ValueError:
-                    if evt.creationInfo().creationTime() < self._modifiedAfterTime:
+                    try:
+                        if evt.creationInfo().creationTime() < self._modifiedAfterTime:
+                            continue
+                    except ValueError:
                         continue
 
             outputString = evt.publicID()

--- a/apps/python/scevtls.py
+++ b/apps/python/scevtls.py
@@ -58,7 +58,8 @@ def readXML(self):
                 if evt.creationInfo().modificationTime() < self._modifiedAfterTime:
                     continue
             except ValueError:
-                continue
+                if evt.creationInfo().creationTime() < self._modifiedAfterTime:
+                    continue
 
         prefOrgID = evt.preferredOriginID()
 
@@ -268,7 +269,8 @@ Print IDs of all events in XML file
                     if evt.creationInfo().modificationTime() < self._modifiedAfterTime:
                         continue
                 except ValueError:
-                    continue
+                    if evt.creationInfo().creationTime() < self._modifiedAfterTime:
+                        continue
 
             outputString = evt.publicID()
             if self._preferredOrigin:


### PR DESCRIPTION
Hi, this PR adds a check for the event creation date in addition to only the modified date in `scevtls`. I noticed that when events are created but not modified they will not show up in the output list when using `--modified-after`. As a user I would like a list of the latest events to review, and skipping new events because they have never been modified seems like a small oversight.