### PR TITLE
[scamp] Arrival.timeUsed is not checked (but it should)

### DIFF
--- a/apps/processing/scamp/amptool.cpp
+++ b/apps/processing/scamp/amptool.cpp
@@ -735,7 +735,8 @@ void AmpTool::process(Origin *origin, Pick *pickInput) {
 
 			double weight = Private::arrivalWeight(arr);
 
-			if ( Private::shortPhaseName(arr->phase().code()) != 'P' || weight < _minWeight ) {
+			if ( Private::shortPhaseName(arr->phase().code()) != 'P' || weight < _minWeight ||
+			     !arr->timeUsed() ) {
 				SEISCOMP_INFO("Ignoring pick '%s' weight=%.1f phase=%s",
 				              pickID.c_str(), weight, arr->phase().code().c_str());
 				continue;


### PR DESCRIPTION
In general this is not a big issue, but this bug is particularly evident when the user set `amptool.minimumPickWeight` to 0 so that arrivals with any weight are used. That causes scamp to process also disabled arrivals, which is not the intended behaviour.