### PR TITLE
[scmag] Arrival.timeUsed is not checked (but it should)

### DIFF
--- a/apps/processing/scmag/dmutil.cpp
+++ b/apps/processing/scmag/dmutil.cpp
@@ -144,7 +144,7 @@ char getShortPhaseName(const string &phase) {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 bool validArrival(const Seiscomp::DataModel::Arrival *arr, double minWeight) {
-	return arrivalWeight(arr) >= minWeight
+	return arrivalWeight(arr) >= minWeight && arr->timeUsed()
 	       && getShortPhaseName(arr->phase().code()) == 'P';
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
In general this is not a big issue, but this bug is particularly evident when the user set `minimumArrivalWeight` (in scmag.cfg) to 0 so that arrivals with any weight are used. That causes `scmag` to process also disabled arrivals, which is not the intended behaviour.