### PR TITLE
[scart] fix to --rename option

### DIFF
--- a/apps/python/scart.py
+++ b/apps/python/scart.py
@@ -461,22 +461,29 @@ class RecordRenamer:
             )
 
     def applyRules(self, rec):
+        matchedRules = []
+        # find rules that match the record
         for rule in self.renameRules:
             if rule.pattern is None or rule.pattern.fullmatch(
                 f"{rec.networkCode()}.{rec.stationCode()}."
                 f"{rec.locationCode()}.{rec.channelCode()}"
             ):
-                if rule.newNet != "-":
-                    rec.setNetworkCode(rule.newNet)
-                if rule.newSta != "-":
-                    rec.setStationCode(rule.newSta)
-                if rule.newLoc != "-":
-                    rec.setLocationCode(rule.newLoc)
-                if rule.newCha != "-":
-                    if len(rule.newCha) == 3 and rule.newCha[2] == "-":
-                        rec.setChannelCode(rule.newCha[0:2] + rec.channelCode()[2])
-                    else:
-                        rec.setChannelCode(rule.newCha)
+                # do not apply the rule here, because it would affect
+                # subsequent matches
+                matchedRules.append(rule)
+        # apply matched rules
+        for rule in matchedRules:
+            if rule.newNet != "-":
+                rec.setNetworkCode(rule.newNet)
+            if rule.newSta != "-":
+                rec.setStationCode(rule.newSta)
+            if rule.newLoc != "-":
+                rec.setLocationCode(rule.newLoc)
+            if rule.newCha != "-":
+                if len(rule.newCha) == 3 and rule.newCha[2] == "-":
+                    rec.setChannelCode(rule.newCha[0:2] + rec.channelCode()[2])
+                else:
+                    rec.setChannelCode(rule.newCha)
 
 
 ####################################################################


### PR DESCRIPTION
If we try to swap station names (e.g. `XP.STA1 <-> XP.STA2`)  with the following command, then `XP.STA1` will not be renamed:

```
scart -n 'XP.STA1,XP.STA2' --rename 'XP.STA1.*.*:-.STA2.-.-'  --rename 'XP.STA2.*.*:-.STA1.-.-' 
```

The first rule would rename `XP.STA1`  to `XP.STA2`, but then the second rule would rename it back to `XP.STA1`