### PR TITLE
Add FM polarity inversion config parameters for scolv

### DIFF
--- a/apps/gui-qt/scolv/mainframe.cpp
+++ b/apps/gui-qt/scolv/mainframe.cpp
@@ -272,6 +272,11 @@ MainFrame::MainFrame(){
 	try { locatorConfig.defaultEventRadius = SCApp->configGetDouble("olv.map.event.defaultRadius"); }
 	catch ( ... ) {}
 
+	try { locatorConfig.fmGridSpacing = SCApp->configGetDouble("olv.fmInversion.gridSpacing"); }
+	catch ( ... ) {}
+	try { locatorConfig.fmMaxBadFraction = SCApp->configGetDouble("olv.fmInversion.maxBadFraction"); }
+	catch ( ... ) {}
+
 	try { pickerConfig.showCrossHair = SCApp->configGetBool("picker.showCrossHairCursor"); }
 	catch ( ... ) {}
 


### PR DESCRIPTION
## Summary

- Add configuration parameters for the automatic first motion polarity inversion feature in scolv: grid spacing and maximum misfit fraction

## Related

- Companion PR: https://github.com/SeisComP/common/pull/177

## Test plan

- [x] Builds successfully with the common PR
- [x] Tested on real events in scolv