### PR TITLE
[fdsnws] Support eduperson_entitlement in JWT

### DIFF
--- a/apps/fdsnws/fdsnws.py
+++ b/apps/fdsnws/fdsnws.py
@@ -269,6 +269,14 @@ class Access:
         except KeyError:
             pass
 
+        try:
+            # New in JWT
+            for memberof in user["eduperson_entitlement"]:
+                matchers.append((self.__matchAttribute, f"{memberof}"))
+
+        except KeyError:
+            pass
+
         for m in matchers:
             for u, start, end in self.__access.get((net, "", "", ""), []):
                 if self.__matchTime(t1, t2, start, end) and m[0](m[1], u):


### PR DESCRIPTION
@javiquinte: does this look OK?

We would also have to expand the "user" field in the database, which is currently varchar(50). Most eduperson entitlements seem to be longer than that:

| eduperson_entitlement | len |
| -----------------------------------|------|
| urn:geant:eudat.eu:group:B2DROP-user#b2access.eudat.eu | 54 |
| urn:geant:eudat.eu:group:EPOS:alparray#b2access.eudat.eu | 56 |
| urn:geant:eudat.eu:group:EPOS:test#b2access.eudat.eu | 52 |
| urn:geant:eudat.eu:group:EPOS:adriaarray#b2access.eudat.eu | 58 |
| urn:geant:eudat.eu:group:EPOS:eidastats#b2access.eudat.eu | 57 |
| urn:geant:eudat.eu:group:EPOS#b2access.eudat.eu | 47 |
