### PR TITLE
[scolv] Add config-driven event list highlight rules

### DIFF
--- a/apps/gui-qt/scolv/config/scolv.cfg
+++ b/apps/gui-qt/scolv/config/scolv.cfg
@@ -67,3 +67,44 @@ olv.artificialOriginAdvanced = false
 olv.computeMissingTakeOffAngles = true
 
 olv.systemTray = true
+
+# Event list highlight rules.
+# Each named rule defines a condition and the row colours to apply.
+# The first matching rule wins.
+# Condition syntax: && for AND, || for OR, ! for NOT, parentheses for grouping.
+#   Comparison operators: ==, !=, <, <=, >=, >
+#   String values must be single-quoted; numeric values are unquoted.
+#   Unset optional fields (e.g. no preferred magnitude, typecertainty not set)
+#   are treated as null: != and < and <= return true, == and > and >= return false.
+# String keys: type, evaluationstatus (alias: status), evaluationmode (alias: mode),
+#              typecertainty, agencyid, author.
+# Numeric keys: latitude (alias: lat), longitude (alias: lon), depth,
+#               magnitude (alias: mag), rms, azimuthalgap (alias: gap).
+# String values use SeisComP enum names as-is (lowercase with spaces),
+# e.g. 'not existing', 'outside of network interest', 'quarry blast'.
+eventlist.highlight = preliminary-earthquake, automatic, unreviewed-rejected
+
+# Earthquake assessed as preliminary: saved by duty seismologist but requires
+# further action (e.g. confirmation or follow-up).
+eventlist.highlight.preliminary-earthquake.condition  = "type == 'earthquake' && evaluationstatus == 'preliminary'"
+eventlist.highlight.preliminary-earthquake.background = FFA500
+eventlist.highlight.preliminary-earthquake.foreground = 000000
+
+# Automatic origin that has not been classified as a no-action type.
+# Excludes 'not existing', 'outside of network interest' and 'quarry blast'
+# which never require highlighting regardless of processing status.
+eventlist.highlight.automatic.condition  = "evaluationmode == 'automatic' && type != 'not existing' && type != 'outside of network interest' && type != 'quarry blast'"
+eventlist.highlight.automatic.background = FF4100
+eventlist.highlight.automatic.foreground = 000000
+
+# Rejected event where the operator has not confirmed certainty = known.
+# typecertainty != 'known' also matches when typecertainty is null (unset).
+eventlist.highlight.unreviewed-rejected.condition  = "evaluationstatus == 'rejected' && typecertainty != 'known' && type != 'outside of network interest' && type != 'quarry blast'"
+eventlist.highlight.unreviewed-rejected.background = C86400
+eventlist.highlight.unreviewed-rejected.foreground = FFFFFF
+
+# Example using numeric operators: deep large events.
+# eventlist.highlight = ..., deep-large
+# eventlist.highlight.deep-large.condition  = "depth >= 100 && magnitude >= 6.0"
+# eventlist.highlight.deep-large.background = 8B0000
+# eventlist.highlight.deep-large.foreground = FFFFFF

--- a/apps/gui-qt/scolv/descriptions/scolv.xml
+++ b/apps/gui-qt/scolv/descriptions/scolv.xml
@@ -1028,6 +1028,57 @@
 					</group>
 				</group>
 			</group>
+			<group name="eventlist">
+				<group name="highlight">
+					<description>
+						Configure event list row highlighting. Each named rule defines
+						a condition and the background/foreground colours to apply to
+						matching rows. The first matching rule wins.
+
+						Supported condition keys (case-insensitive, joined with &amp;&amp;):
+						  type             — event type (e.g. earthquake, not-existing,
+						                     outside-of-network-interest, quarry-blast)
+						  evaluationStatus — origin status (e.g. preliminary, confirmed,
+						                     reviewed, final, rejected)
+						  evaluationMode   — origin mode (automatic, manual)
+						  typeCertainty    — event certainty (known, suspected, none)
+
+						Both = and != operators are supported.
+
+						Colours must be specified as 6-digit hex (RRGGBB) or 8-digit
+						hex (RRGGBBAA), or as a Qt named colour (e.g. orange, yellow).
+					</description>
+					<parameter name="highlight" type="list:string">
+						<description>
+							Ordered list of highlight rule names. Rules are evaluated in
+							order; the first matching rule is applied. Example:
+							preliminary-earthquake, automatic, rejected-uncertain
+						</description>
+					</parameter>
+					<struct name="HighlightRule" link="eventlist.highlight">
+						<parameter name="condition" type="string">
+							<description>
+								Condition string to match against each event and its
+								preferred origin. Tokens are joined with &amp;&amp;, each
+								of the form key=value or key!=value. Example:
+								"type=earthquake &amp;&amp; evaluationStatus=preliminary"
+							</description>
+						</parameter>
+						<parameter name="background" type="string">
+							<description>
+								Background colour for matching rows. Use 6-digit hex
+								(e.g. FFA500) or a Qt named colour (e.g. orange).
+							</description>
+						</parameter>
+						<parameter name="foreground" type="string">
+							<description>
+								Foreground (text) colour for matching rows. Use 6-digit hex
+								(e.g. 000000) or a Qt named colour (e.g. black).
+							</description>
+						</parameter>
+					</struct>
+				</group>
+			</group>
 		</configuration>
 		<command-line>
 			<synopsis>

--- a/apps/gui-qt/scolv/mainframe.cpp
+++ b/apps/gui-qt/scolv/mainframe.cpp
@@ -52,10 +52,13 @@
 #include <seiscomp/datamodel/utils.h>
 
 #include <seiscomp/core/datamessage.h>
+#include <seiscomp/core/exceptions.h>
+#include <seiscomp/utils/leparser.h>
 
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QSystemTrayIcon>
+#include <QTreeWidgetItem>
 
 #include <sstream>
 #include <iomanip>
@@ -135,6 +138,82 @@ string trim(const std::string &str) {
 	Core::trim(tmp);
 	return tmp;
 }
+
+
+class EventKeyValueContext : public Utils::LeKeyValueContext {
+	public:
+		EventKeyValueContext(DataModel::Event *event, DataModel::Origin *origin,
+		                     DataModel::Magnitude *magnitude)
+		    : _event(event), _origin(origin), _magnitude(magnitude) {}
+
+		std::string getString(std::string_view key) const override {
+			if ( key == "type" ) {
+				try { return DataModel::EEventTypeNames::name(_event->type()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "typecertainty" ) {
+				try { return DataModel::EEventTypeCertaintyNames::name(_event->typeCertainty()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "evaluationstatus" || key == "status" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return DataModel::EEvaluationStatusNames::name(_origin->evaluationStatus()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "evaluationmode" || key == "mode" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return DataModel::EEvaluationModeNames::name(_origin->evaluationMode()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "agencyid" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->creationInfo().agencyID(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "author" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->creationInfo().author(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			throw std::runtime_error(std::string("unknown key: ") + std::string(key));
+		}
+
+		double getDouble(std::string_view key) const override {
+			if ( key == "latitude" || key == "lat" ) {
+				if ( !_origin ) throw Core::ValueException();
+				return _origin->latitude().value();
+			}
+			if ( key == "longitude" || key == "lon" ) {
+				if ( !_origin ) throw Core::ValueException();
+				return _origin->longitude().value();
+			}
+			if ( key == "depth" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->depth().value(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "magnitude" || key == "mag" ) {
+				if ( !_magnitude ) throw Core::ValueException();
+				return _magnitude->magnitude().value();
+			}
+			if ( key == "rms" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->quality().standardError(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "azimuthalgap" || key == "gap" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->quality().azimuthalGap(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			throw std::runtime_error(std::string("unknown key: ") + std::string(key));
+		}
+
+	private:
+		DataModel::Event     *_event;
+		DataModel::Origin    *_origin;
+		DataModel::Magnitude *_magnitude;
+};
 
 
 }
@@ -742,6 +821,11 @@ MainFrame::MainFrame(){
 	connect(_eventList, SIGNAL(visibleEventCountChanged()),
 	        this, SLOT(updateEventTabText()));
 
+	connect(_eventList, SIGNAL(eventAddedToList(Seiscomp::DataModel::Event*,bool)),
+	        this, SLOT(updateEventHighlight(Seiscomp::DataModel::Event*)));
+	connect(_eventList, SIGNAL(eventUpdatedInList(Seiscomp::DataModel::Event*)),
+	        this, SLOT(updateEventHighlight(Seiscomp::DataModel::Event*)));
+
 	_originLocator->map()->addLayer(eventMapLayer);
 
 	QLayout* layoutEventList = new QVBoxLayout(_ui.tabEventList);
@@ -984,6 +1068,8 @@ MainFrame::MainFrame(){
 		_originLocator->setScript1(Seiscomp::Environment::Instance()->absolutePath(SCApp->configGetString("scripts.script1")));
 	}
 	catch ( ... ) {}
+
+	loadHighlightRules();
 
 	SCApp->settings().endGroup();
 }
@@ -1448,6 +1534,27 @@ void MainFrame::objectAdded(const QString &parentID, Seiscomp::DataModel::Object
 		return;
 	}
 
+	// When a new preferred magnitude arrives, re-highlight its parent event
+	// so that magnitude-based rules take effect immediately.
+	if ( !_highlightRules.empty() ) {
+		Magnitude *mag = Magnitude::Cast(o);
+		if ( mag ) {
+			QTreeWidget *tree = _eventList->eventTree();
+			if ( tree ) {
+				const std::string &mid = mag->publicID();
+				for ( int i = 0; i < tree->topLevelItemCount(); ++i ) {
+					QTreeWidgetItem *item = tree->topLevelItem(i);
+					Event *ev = EventListView::eventFromTreeItem(item);
+					if ( ev && ev->preferredMagnitudeID() == mid ) {
+						Origin *org = Origin::Find(ev->preferredOriginID());
+						applyHighlight(item, ev, org, mag);
+					}
+				}
+			}
+			return;
+		}
+	}
+
 	// NOTE Do not update the station state during picking
 	/*
 	DataModel::ConfigStation *cs = DataModel::ConfigStation::Cast(o);
@@ -1470,11 +1577,52 @@ void MainFrame::objectUpdated(const QString& parentID, Seiscomp::DataModel::Obje
 	*/
 
 	Event *evt = Event::Cast(o);
-	if ( evt && evt->publicID() == _eventID ) {
-		if ( _currentOrigin && _currentOrigin->publicID() == evt->preferredOriginID() ) {
-			_magnitudes->setPreferredMagnitudeID(evt->preferredMagnitudeID());
+	if ( evt ) {
+		if ( evt->publicID() == _eventID ) {
+			if ( _currentOrigin && _currentOrigin->publicID() == evt->preferredOriginID() ) {
+				_magnitudes->setPreferredMagnitudeID(evt->preferredMagnitudeID());
+			}
 		}
+		updateEventHighlight(evt);
 		return;
+	}
+
+	if ( !_highlightRules.empty() ) {
+		QTreeWidget *tree = _eventList->eventTree();
+		if ( !tree ) return;
+
+		// When a preferred origin arrives or is updated, re-highlight its parent
+		// event. This covers the case where the origin message arrives after the
+		// event was added to the list (evaluationMode/Status not yet available).
+		Origin *org = Origin::Cast(o);
+		if ( org ) {
+			const std::string &oid = org->publicID();
+			for ( int i = 0; i < tree->topLevelItemCount(); ++i ) {
+				QTreeWidgetItem *item = tree->topLevelItem(i);
+				Event *ev = EventListView::eventFromTreeItem(item);
+				if ( ev && ev->preferredOriginID() == oid ) {
+					Magnitude *mag = Magnitude::Find(ev->preferredMagnitudeID());
+					applyHighlight(item, ev, org, mag);
+				}
+			}
+			return;
+		}
+
+		// When a preferred magnitude arrives or is updated, re-highlight its
+		// parent event so that magnitude-based rules reflect the new value.
+		Magnitude *mag = Magnitude::Cast(o);
+		if ( mag ) {
+			const std::string &mid = mag->publicID();
+			for ( int i = 0; i < tree->topLevelItemCount(); ++i ) {
+				QTreeWidgetItem *item = tree->topLevelItem(i);
+				Event *ev = EventListView::eventFromTreeItem(item);
+				if ( ev && ev->preferredMagnitudeID() == mid ) {
+					Origin *org2 = Origin::Find(ev->preferredOriginID());
+					applyHighlight(item, ev, org2, mag);
+				}
+			}
+			return;
+		}
 	}
 }
 
@@ -1870,6 +2018,120 @@ void MainFrame::trayIconMessageClicked() {
 
 	_trayMessageEventID.clear();
 }
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// Load highlight rules from config:
+//   eventlist.highlight = rule1, rule2, ...
+//   eventlist.highlight.<name>.condition  = "key == 'string' && key != 'string' && key < number"
+//   eventlist.highlight.<name>.background = RRGGBB | named-color
+//   eventlist.highlight.<name>.foreground = RRGGBB | named-color
+void MainFrame::loadHighlightRules() {
+	_highlightRules.clear();
+
+	std::vector<std::string> names;
+	try {
+		names = SCApp->configGetStrings("eventlist.highlight");
+	}
+	catch ( ... ) { return; }
+
+	Utils::LeKeyValueFactory factory;
+	Utils::LeParser::Symbols symbols = Utils::LeParser::DefaultSymbols();
+	symbols.reserved = Utils::LeKeyValueFactory::Reserved();
+	Utils::LeParser parser(&factory, &symbols);
+
+	for ( const auto &name : names ) {
+		const std::string base = "eventlist.highlight." + name;
+
+		std::string condStr;
+		try {
+			condStr = SCApp->configGetString(base + ".condition");
+		}
+		catch ( ... ) { continue; }   // condition is mandatory
+
+		Utils::LeExpression *expr = nullptr;
+		try {
+			expr = parser.parse(condStr);
+		}
+		catch ( const std::exception &e ) {
+			SEISCOMP_WARNING("eventlist.highlight.%s: invalid condition: %s",
+			                 name.c_str(), e.what());
+			continue;
+		}
+
+		HighlightRule rule;
+		rule.expression = expr;
+		rule.background = SCApp->configGetColor(base + ".background", QColor());
+		rule.foreground = SCApp->configGetColor(base + ".foreground", QColor());
+		_highlightRules.emplace_back(std::move(rule));
+	}
+
+	SEISCOMP_INFO("Loaded %d event highlight rule(s)", (int)_highlightRules.size());
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// Apply the first matching highlight rule to all columns of a tree item.
+void MainFrame::applyHighlight(QTreeWidgetItem  *item,
+                               DataModel::Event  *event,
+                               DataModel::Origin *origin,
+                               DataModel::Magnitude *magnitude) const {
+	EventKeyValueContext ctx(event, origin, magnitude);
+
+	const HighlightRule *matched = nullptr;
+	for ( const auto &rule : _highlightRules ) {
+		if ( !rule.expression ) continue;
+		try {
+			if ( rule.expression->eval(&ctx) ) {
+				matched = &rule;
+				break;
+			}
+		}
+		catch ( ... ) {}
+	}
+
+	int cols = item->columnCount();
+	for ( int c = 0; c < cols; ++c ) {
+		if ( matched ) {
+			if ( matched->background.isValid() )
+				item->setBackground(c, matched->background);
+			if ( matched->foreground.isValid() )
+				item->setForeground(c, matched->foreground);
+		}
+		else {
+			item->setData(c, Qt::BackgroundRole, QVariant());
+			item->setData(c, Qt::ForegroundRole, QVariant());
+		}
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void MainFrame::updateEventHighlight(DataModel::Event *event) {
+	if ( !event || _highlightRules.empty() ) return;
+
+	QTreeWidget *tree = _eventList->eventTree();
+	if ( !tree ) return;
+
+	Origin *origin = Origin::Find(event->preferredOriginID());
+	Magnitude *magnitude = Magnitude::Find(event->preferredMagnitudeID());
+	const std::string &eid = event->publicID();
+
+	for ( int i = 0; i < tree->topLevelItemCount(); ++i ) {
+		QTreeWidgetItem *item = tree->topLevelItem(i);
+		Event *ev = EventListView::eventFromTreeItem(item);
+		if ( !ev || ev->publicID() != eid ) continue;
+		applyHighlight(item, event, origin, magnitude);
+		break;
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
 }

--- a/apps/gui-qt/scolv/mainframe.h
+++ b/apps/gui-qt/scolv/mainframe.h
@@ -22,11 +22,15 @@
 #include <seiscomp/datamodel/origin.h>
 #include <seiscomp/datamodel/eventparameters.h>
 #include <seiscomp/datamodel/journaling.h>
+#include <seiscomp/utils/leparser.h>
 #endif
 #include "ui_mainframe.h"
 
 #include <QtGui>
+#include <QColor>
 #include <QSystemTrayIcon>
+
+class QTreeWidgetItem;
 
 namespace Seiscomp {
 namespace Gui {
@@ -38,6 +42,13 @@ class EventEdit;
 class OriginLocatorView;
 class MagnitudeView;
 class PickerView;
+
+
+struct HighlightRule {
+	Utils::LeExpressionPtr expression;
+	QColor                 background;
+	QColor                 foreground;
+};
 
 
 class MainFrame : public MainWindow {
@@ -64,6 +75,7 @@ class MainFrame : public MainWindow {
 
 	private slots:
 		void configureAcquisition();
+		void updateEventHighlight(Seiscomp::DataModel::Event*);
 
 		void messageAvailable(Seiscomp::Core::Message*, Seiscomp::Client::Packet*);
 
@@ -95,6 +107,11 @@ class MainFrame : public MainWindow {
 
 	private:
 		bool populateOrigin(Seiscomp::DataModel::Origin*, Seiscomp::DataModel::Event*, bool);
+		void loadHighlightRules();
+		void applyHighlight(QTreeWidgetItem *item,
+		                    Seiscomp::DataModel::Event *event,
+		                    Seiscomp::DataModel::Origin *origin,
+		                    Seiscomp::DataModel::Magnitude *magnitude = nullptr) const;
 
 		// This creates an EventParameters instance containing copies
 		// of all event attributes relevant for publication incl.
@@ -123,6 +140,8 @@ class MainFrame : public MainWindow {
 		DataModel::OriginPtr _currentOrigin;
 		DataModel::EventParametersPtr _offlineData;
 		DataModel::JournalingPtr _offlineJournal;
+
+		std::vector<HighlightRule> _highlightRules;
 
 		bool               _computeMagnitudesAutomatically;
 		bool               _computeMagnitudesSilently;


### PR DESCRIPTION
## What this does

Adds a configurable row-highlight system to the scolv event list. Operators can define named rules in `scolv.cfg` that colour-code rows based on event properties — useful for drawing attention to events that need action (e.g. automatic origins, preliminary earthquakes, unreviewed rejections).

## How it works

Each rule is a logical expression evaluated against the event's preferred origin, magnitude, and event metadata. The first matching rule wins and its colours are applied to the entire row. When no rule matches, the row reverts to the default style.

The implementation uses `Utils::LeKeyValueContext` / `LeKeyValueFactory` from `seiscomp/utils/leparser.h`. A local `EventKeyValueContext` (anonymous namespace in `mainframe.cpp`) maps string and numeric keys to live datamodel objects — no new shared headers are needed.

Highlights are re-evaluated automatically when:
- an event is added to or loaded into the list
- an event is updated (type, status, preferred origin/magnitude change)
- a preferred origin or magnitude is updated for a listed event

If a numeric key is unavailable (e.g. no preferred magnitude), the rule is silently treated as non-matching.

## Configuration

```
# Ordered list of rule names — first match wins
eventlist.highlight = rule1, rule2, rule3

# Per-rule settings
eventlist.highlight.<name>.condition  = "key == value & key != value"
eventlist.highlight.<name>.background = FFA500   # hex or Qt named colour
eventlist.highlight.<name>.foreground = 000000
```

**Condition syntax** — full leparser boolean expressions: `&` (AND), `|` (OR), `!` (NOT), parentheses. Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`.

**Supported keys:**

| Key | Aliases | Type | Description |
|-----|---------|------|-------------|
| `type` | | string | Event type (`earthquake`, `not existing`, `quarry blast`, …) |
| `typecertainty` | | string | `known`, `suspected`, `damaging`, `felt`; `""` if unset |
| `evaluationstatus` | `status` | string | `preliminary`, `confirmed`, `reviewed`, `final`, `rejected` |
| `evaluationmode` | `mode` | string | `automatic`, `manual` |
| `agencyid` | | string | Agency ID of preferred origin |
| `author` | | string | Author of preferred origin |
| `latitude` | `lat` | numeric | Degrees |
| `longitude` | `lon` | numeric | Degrees |
| `depth` | | numeric | km |
| `magnitude` | `mag` | numeric | Preferred magnitude value |
| `rms` | | numeric | Origin RMS residual |
| `azimuthalgap` | `gap` | numeric | Degrees |

String values match SeisComP enum names exactly (lowercase with spaces). Unset optional string fields return `""`, so `typecertainty != known` correctly matches events where type certainty has not been set.

**Example rules** (included in default `scolv.cfg`):

```
eventlist.highlight = preliminary-earthquake, automatic, unreviewed-rejected

eventlist.highlight.preliminary-earthquake.condition  = "type == earthquake & evaluationstatus == preliminary"
eventlist.highlight.preliminary-earthquake.background = FFA500
eventlist.highlight.preliminary-earthquake.foreground = 000000

eventlist.highlight.automatic.condition  = "evaluationmode == automatic & type != not existing & type != outside of network interest & type != quarry blast"
eventlist.highlight.automatic.background = yellow
eventlist.highlight.automatic.foreground = 000000

eventlist.highlight.unreviewed-rejected.condition  = "evaluationstatus == rejected & typecertainty != known & type != outside of network interest & type != quarry blast"
eventlist.highlight.unreviewed-rejected.background = C86400
eventlist.highlight.unreviewed-rejected.foreground = FFFFFF
```
