### PR TITLE
[scautoloc] Export secondaryAzimuthalGap in OriginQuality

### DIFF
--- a/apps/processing/scautoloc/sc3adapters.cpp
+++ b/apps/processing/scautoloc/sc3adapters.cpp
@@ -144,7 +144,15 @@ Seiscomp::DataModel::Origin *convertToSC(const Autoloc::Origin* origin, bool all
 	origin->geoProperties(minDist, maxDist, aziGap);
 	oq.setMinimumDistance(minDist);
 	oq.setMaximumDistance(maxDist);
-	oq.setAzimuthalGap(aziGap);
+
+	double primaryGap, secondaryGap;
+	if ( determineAzimuthalGaps(origin, &primaryGap, &secondaryGap) ) {
+		oq.setAzimuthalGap(primaryGap);
+		oq.setSecondaryAzimuthalGap(secondaryGap);
+	}
+	else {
+		oq.setAzimuthalGap(aziGap);
+	}
 
 	scorigin->setQuality(oq);
 

--- a/apps/processing/scautoloc/util.cpp
+++ b/apps/processing/scautoloc/util.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 
 #include "util.h"
+#include "locator.h"
 #include "nucleator.h"
 #include "datamodel.h"
 
@@ -611,7 +612,15 @@ DataModel::Origin *convertToSC(const AutolocInternal::Origin* origin, const std:
 	origin->geoProperties(minDist, maxDist, aziGap);
 	oq.setMinimumDistance(minDist);
 	oq.setMaximumDistance(maxDist);
-	oq.setAzimuthalGap(aziGap);
+
+	double primaryGap, secondaryGap;
+	if ( determineAzimuthalGaps(origin, &primaryGap, &secondaryGap) ) {
+		oq.setAzimuthalGap(primaryGap);
+		oq.setSecondaryAzimuthalGap(secondaryGap);
+	}
+	else {
+		oq.setAzimuthalGap(aziGap);
+	}
 
 	scorigin->setQuality(oq);
 


### PR DESCRIPTION
## Problem

scautoloc computes the secondary azimuthal gap internally via `determineAzimuthalGaps()` and uses it as a rejection criterion, but the value was **never written into `OriginQuality`** when exporting the origin to SeisComP. As a result, scautoloc origins always have `secondaryAzimuthalGap` unset — unlike stdloc and scrtdd which both populate it.

This was confirmed as an oversight by @jsaul:
> "Certainly an oversight. There is `determineAzimuthalGaps()` and `geoProperties()`; the latter was implemented by someone else."

## Fix

Call `determineAzimuthalGaps()` in `convertToSC()` (sc3adapters.cpp) and set `secondaryAzimuthalGap` on the exported `OriginQuality`. The function was already available and correct — it just wasn't called at export time.

## Related

Companion PR in SeisComP/common adds a standalone `computeAzimuthalGaps(azimuths, primary*, secondary*)` library function so the algorithm has a single home, as @jsaul suggested: SeisComP/common#193