### PR TITLE
[scrttv] Expose missing stream display params in scconfig; connect Y-zoom floor to streams.height

### DIFF
--- a/apps/gui-qt/scrttv/descriptions/scrttv.xml
+++ b/apps/gui-qt/scrttv/descriptions/scrttv.xml
@@ -163,6 +163,32 @@
 					than rows are loaded, the are accessible by a scroll bar.
 					</description>
 				</parameter>
+				<parameter name="height" type="int" unit="px">
+					<description>
+					Row height in pixels. Sets the minimum row height and the
+					initial maximum, so rows start at this size. Also defines the
+					lower bound for the vertical zoom hotkey (Y), replacing the
+					built-in 16 px default. After a Default Display reset or zoom-in
+					the maximum constraint is released and rows may grow above this
+					value.
+					</description>
+				</parameter>
+				<parameter name="rowSpacing" type="int" unit="px" default="0">
+					<description>
+					Pixel gap between rows.
+					</description>
+				</parameter>
+				<parameter name="withFrames" type="boolean" default="false">
+					<description>
+					Draw frames around individual trace rows.
+					</description>
+				</parameter>
+				<parameter name="frameMargin" type="int" unit="px" default="0">
+					<description>
+					Pixel margin inside each trace frame. Only effective when
+					streams.withFrames is enabled.
+					</description>
+				</parameter>
 				<group name="region">
 					<description>
 					Define a region used for clipping requested stations.

--- a/apps/gui-qt/scrttv/mainwindow.cpp
+++ b/apps/gui-qt/scrttv/mainwindow.cpp
@@ -1634,6 +1634,7 @@ TraceView* MainWindow::createTraceView() {
 	traceView->setFramesEnabled(_withFrames);
 	traceView->setFrameMargin(_frameMargin);
 	if ( _rowHeight > 0 ) {
+		traceView->setDefaultRowHeight(_rowHeight);
 		traceView->setMinimumRowHeight(_rowHeight);
 		traceView->setMaximumRowHeight(_rowHeight);
 	}


### PR DESCRIPTION
## Summary

Several `scrttv` configuration parameters are functional in code but invisible in scconfig because they have no entries in `scrttv.xml`. Additionally, the vertical zoom hotkey (**Y**) has a hardcoded minimum row height that cannot be overridden by configuration.

## Changes

**`scrttv.xml`** — add missing parameter descriptions so they appear in scconfig:

| Parameter | Type | Description |
|-----------|------|-------------|
| `streams.height` | int (px) | Row height floor; also caps initial max so rows start at this size |
| `streams.rowSpacing` | int (px) | Pixel gap between rows |
| `streams.withFrames` | boolean | Draw frames around individual trace rows |
| `streams.frameMargin` | int (px) | Pixel margin inside each trace frame |

**`mainwindow.cpp`** — call `setDefaultRowHeight(_rowHeight)` alongside the existing `setMinimumRowHeight`/`setMaximumRowHeight` calls when `streams.height` is configured.

This connects the **Y-key vertical zoom floor** to `streams.height` instead of leaving it at the hardcoded 16 px default in `RecordView`. It also fixes a secondary issue: without this, pressing the *Default Display* menu action at runtime would silently reset the row minimum back to 16 px even when `streams.height` is set.

## Behaviour after this change

- `streams.height = 12` → rows start at 12 px; Y key cannot zoom out below 12 px
- Default Display action resets to auto-fit but respects `streams.height` as the floor
- Zoom-in (Shift+Y) releases the max constraint as before

## Related

Follows the same pattern used in `pickerview.cpp` and `amplitudeview.cpp` which both call `setDefaultRowHeight` with a font-metrics-based value.