### PR TITLE
[scautoloc] Add DepthLookup plugin support via factory interface

### DIFF
--- a/apps/processing/scautoloc/app.cpp
+++ b/apps/processing/scautoloc/app.cpp
@@ -314,6 +314,11 @@ bool AutolocApp::initConfiguration() {
 	catch ( ... ) {}
 
 	try {
+		_config.depthLookupType = configGetString("autoloc.depthLookup");
+	}
+	catch ( ... ) {}
+
+	try {
 		_config.maxResidualUse = configGetDouble("autoloc.maxResidual");
 	}
 	catch ( ... ) {}

--- a/apps/processing/scautoloc/autoloc.cpp
+++ b/apps/processing/scautoloc/autoloc.cpp
@@ -81,8 +81,33 @@ bool Autoloc::init() {
 	SEISCOMP_DEBUG("Setting configured locator profile: %s", _config.locatorProfile);
 	setLocatorProfile(_config.locatorProfile);
 
+	_depthLookup = Seismology::DepthLookupFactory::Create(_config.depthLookupType);
+	if ( !_depthLookup ) {
+		if ( _config.depthLookupType != "Constant" )
+			SEISCOMP_WARNING("DepthLookup '%s' not available — falling back to Constant",
+			                 _config.depthLookupType.c_str());
+		_depthLookup = Seismology::DepthLookupFactory::Create("Constant");
+	}
+	if ( _depthLookup && _config.scconfig )
+		_depthLookup->init(*_config.scconfig);
+
 	return true; // ready to start processing
 }
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+double Autoloc::_defaultDepthAt(const Origin *origin) const {
+	return _depthLookup
+	    ? _depthLookup->fetch(origin->hypocenter.lat, origin->hypocenter.lon)
+	    : _config.defaultDepth;
+}
+
+double Autoloc::_maxDepthAt(const Origin *origin) const {
+	return _depthLookup
+	    ? _depthLookup->fetchMaxDepth(origin->hypocenter.lat, origin->hypocenter.lon)
+	    : _config.maxDepth;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
@@ -1879,7 +1904,7 @@ bool Autoloc::_setDefaultDepth(Origin *origin)
 {
 	OriginPtr test = new Origin(*origin);
 
-	_relocator.setFixedDepth(_config.defaultDepth);
+	_relocator.setFixedDepth(_defaultDepthAt(origin));
 	_relocator.useFixedDepth(true);
 	OriginPtr relo = _relocator.relocate(test.get());
 	if ( !relo ) {
@@ -1920,7 +1945,8 @@ bool Autoloc::_setTheRightDepth(Origin *origin) {
 			return false;
 		}
 
-		double radius = 5*(relo->hypocenter.dep >= _config.defaultDepth ? relo->hypocenter.dep : _config.defaultDepth)/111.2;
+		double dd = _defaultDepthAt(origin);
+		double radius = 5*(relo->hypocenter.dep >= dd ? relo->hypocenter.dep : dd)/111.2;
 
 		// XXX This is a hack, but better than nothing:
 		// if there are at least 2 stations within 5 times the source depth, we assume sufficient depth resolution.
@@ -2110,7 +2136,7 @@ bool Autoloc::_rework(Origin *origin) {
 	}
 
 	if ( enforceDefaultDepth ) {
-		_relocator.setFixedDepth(_config.defaultDepth);
+		_relocator.setFixedDepth(_defaultDepthAt(origin));
 	}
 
 	bool keepDepth = adoptManualDepth || enforceDefaultDepth;
@@ -2159,7 +2185,7 @@ bool Autoloc::_rework(Origin *origin) {
 	_excludeDistantStations(origin);
 	_excludePKP(origin);
 
-	if ( origin->hypocenter.dep != _config.defaultDepth && origin->depthType == Origin::DepthDefault )
+	if ( origin->hypocenter.dep != _defaultDepthAt(origin) && origin->depthType == Origin::DepthDefault )
 		origin->depthType = Origin::DepthFree;
 
 	// once more (see also above)
@@ -2391,9 +2417,9 @@ bool Autoloc::_publishable(const Origin *origin) const
 	}
 
 
-	if ( origin->hypocenter.dep > _config.maxDepth ) {
+	if ( origin->hypocenter.dep > _maxDepthAt(origin) ) {
 		SEISCOMP_INFO("Origin %ld too deep: %.1f km > %.1f km (maxDepth)",
-			      origin->id, origin->hypocenter.dep, _config.maxDepth);
+			      origin->id, origin->hypocenter.dep, _maxDepthAt(origin));
 		return false;
 	}
 
@@ -2443,7 +2469,7 @@ bool Autoloc::_store(Origin *origin)
 	}
 
 	if ( origin->depthType == Origin::DepthDefault &&
-	    origin->hypocenter.dep != _config.defaultDepth ) {
+	    origin->hypocenter.dep != _defaultDepthAt(origin) ) {
 		origin->depthType = Origin::DepthFree;
 	}
 
@@ -2537,7 +2563,7 @@ bool Autoloc::_associate(Origin *origin, const Pick *pick, const std::string &ph
 			bool fixed = false;
 			if ( _config.defaultDepthStickiness > 0.9 ) {
 				fixed = true;
-				_relocator.setFixedDepth(_config.defaultDepth);
+				_relocator.setFixedDepth(_defaultDepthAt(origin));
 			}
 
 //			else if ( origin->depthType == Origin::DepthManuallyFixed || origin->depthType == Origin::DepthPhases ) {
@@ -3528,7 +3554,7 @@ bool Autoloc::_depthIsResolvable(Origin *origin) {
 //		return true;
 //	}
 
-	if ( origin->depthType == Origin::DepthDefault && origin->hypocenter.dep != _config.defaultDepth )
+	if ( origin->depthType == Origin::DepthDefault && origin->hypocenter.dep != _defaultDepthAt(origin) )
 		origin->depthType = Origin::DepthFree;
 
 	OriginPtr test = new Origin(*origin);
@@ -3547,7 +3573,7 @@ bool Autoloc::_depthIsResolvable(Origin *origin) {
 	}
 
 	test = new Origin(*origin);
-	test->hypocenter.dep = _config.defaultDepth;
+	test->hypocenter.dep = _defaultDepthAt(origin);
 	_relocator.useFixedDepth(true);
 	relo = _relocator.relocate(test.get());
 	if ( !relo ) {

--- a/apps/processing/scautoloc/autoloc.h
+++ b/apps/processing/scautoloc/autoloc.h
@@ -20,6 +20,8 @@
 #include <map>
 #include <set>
 
+#include <seiscomp/seismology/depthlookup.h>
+
 #include "datamodel.h"
 #include "nucleator.h"
 #include "associator.h"
@@ -262,6 +264,9 @@ class Autoloc {
 		// if successful, true is returned, otherwise false
 		bool _setDefaultDepth(AutolocInternal::Origin*);
 
+		double _defaultDepthAt(const AutolocInternal::Origin*) const;
+		double _maxDepthAt(const AutolocInternal::Origin*) const;
+
 		// Attempt to decide whether the focal depth can be resolved considering
 		// the station distribution. Returns true if resolvable, false if not.
 		bool _depthIsResolvable(AutolocInternal::Origin*);
@@ -364,6 +369,8 @@ class Autoloc {
 		AutolocInternal::OriginVector _origins;
 		AutolocConfig _config;
 		AutolocInternal::StationConfig _stationConfig;
+
+		Seismology::DepthLookupPtr _depthLookup;
 
 		const Seiscomp::Config::Config *scconfig {nullptr};
 		const Seiscomp::DataModel::Inventory *scinventory {nullptr};

--- a/apps/processing/scautoloc/config.cpp
+++ b/apps/processing/scautoloc/config.cpp
@@ -44,6 +44,7 @@ void AutolocConfig::dump() const {
 	SEISCOMP_INFO("    maxResidual                      %.1f s", maxResidualUse);
 	SEISCOMP_INFO("    maxResidual for keeping picks    %.1f s", maxResidualKeep);
 	SEISCOMP_INFO("    minPhaseCount                    %d",     minPhaseCount);
+	SEISCOMP_INFO("    depthLookup                      %s",     depthLookupType.c_str());
 	SEISCOMP_INFO("    maxDepth                         %.1f km", maxDepth);
 	SEISCOMP_INFO("    minStaCountIgnorePKP             %d",     minStaCountIgnorePKP);
 	SEISCOMP_INFO("    defaultDepthStickiness           %g",     defaultDepthStickiness);

--- a/apps/processing/scautoloc/config.h
+++ b/apps/processing/scautoloc/config.h
@@ -91,6 +91,10 @@ struct AutolocConfig {
 		//    maxResidualUse  = 2*maxRMS
 
 
+		// DepthLookup backend: "Constant" (default), or any registered plugin
+		// e.g. "Slab2" when slab2depthlookup plugin is loaded.
+		std::string depthLookupType{"Constant"};
+
 		// Use this depth if there is no depth resolution
 		double defaultDepth{10.0};           // unit: km
 		double defaultDepthStickiness{0.5};  // 0...1


### PR DESCRIPTION
## Summary

- Wires scautoloc to the `Seismology::DepthLookupFactory` from seiscomp/common (PR #199)
- Removes any local backend implementation — depth lookup is fully delegated to the registered plugin
- Adds `_defaultDepthAt()` / `_maxDepthAt()` helpers that replace `_config.defaultDepth` and `_config.maxDepth` at all geographic-lookup call sites
- Default behaviour is unchanged: `autoloc.depthLookup = Constant` (the built-in backend from common)

## How to use

Load a DepthLookup plugin and set the backend in `scautoloc.cfg`:

```ini
plugins              = slab2depthlookup
autoloc.depthLookup  = Slab2
```

The Slab2 backend is provided by https://github.com/comoglu/seiscomp-slab2-plugin — a standalone installable plugin using USGS Slab2.0 depth-contour BNA files. Proof-of-concept tested with a live playback: plugin loads 531 BNA files across 30 zones and correctly identifies slab depths (e.g. Kuril zone at 40 km).

## Relationship to previous PRs

Supersedes PR #126 (`feature/depthlookup-v2`), which compiled Slab2 directly into scautoloc. This branch takes the cleaner approach agreed with Joachim and Jan: scautoloc is a plugin consumer only, backends live outside.

## Test plan

- [x] `autoloc.depthLookup = Constant` (default) — no behaviour change, existing tests pass
- [x] `autoloc.depthLookup = Slab2` with slab2depthlookup plugin loaded — slab depth applied, verified in log
- [x] Outside slab coverage — fallback depth used correctly