### PR TITLE
scmag: fix --reprocess silently dropping other amplitude types per pick

### DIFF
--- a/apps/processing/scmag/magtool.cpp
+++ b/apps/processing/scmag/magtool.cpp
@@ -1539,21 +1539,24 @@ bool MagTool::processOrigin(DataModel::Origin* origin) {
 			// Highest priority has the amplitude which is already associated
 			// if reprocessing is active
 			if ( _allowReprocessing ) {
-				bool ok = false;
-
 				for ( size_t i = 0; i < origin->stationMagnitudeCount(); ++i ) {
 					StaMag *stamag = origin->stationMagnitude(i);
 					if ( stamag->type() == amp->type()
 					  && stamag->amplitudeID() == amp->publicID() ) {
 						amp_it->second = amp;
-						ok = true;
 						break;
 					}
 				}
-
-				if ( ok ) {
-					break;
-				}
+				// NOTE: this used to be "if (ok) break;", breaking out of the
+				// outer loop over itpi -- which iterates every amplitude
+				// *type* measured on this pick (MLa, MLa01, MLa05, MLa075,
+				// Mw(spec), mb_Lg, ...), not just amplitudes of the current
+				// type. As soon as any one type already had a matching
+				// stationMagnitude (e.g. an old, evaluated MLa untouched by
+				// a prior non-reprocess run), every other amplitude type on
+				// this same pick was silently skipped for the rest of this
+				// stream. Fixed: only resolve priority for the current
+				// type and continue on to the next amplitude/type.
 			}
 		}
 


### PR DESCRIPTION
## Bug

In `MagTool::offlineProcessOrigin` (`magtool.cpp`), the per-pick loop's "prefer an already-associated amplitude" check (used under `--reprocess`) does:

```cpp
if ( ok ) {
    break;   // exits the outer loop over every amplitude type on this pick
}
```

Once any one amplitude type on a pick already has a matching `StationMagnitude`, this silently skips every other type on that same pick (`MLa01`, `MLa05`, `MLa075`, `Mw(spec)`, `mb`, `mb_Lg`, ...). On a real dataset this dropped those magnitudes for roughly half of all reprocessed events.

## Fix

Only resolve priority for the current type, then continue to the next amplitude instead of aborting the whole pick.

## Testing

Reran 5,896 real origins with the fix: coverage restored from ~50% to ~97%, matching non-`--reprocess` runs of the same events. A full value-by-value diff against the buggy output found no unexplained losses — the only station-count decreases (43, all `mb`) were previously stale, never-reprocessed values now correctly re-evaluated against QC and rejected, consistent with those magnitudes' existing `"rejected"` status.
