### PR TITLE
[magnitudes] Mwpd: document low-magnitude usage guidance

### DIFF
--- a/plugins/magnitudes/mwpd/descriptions/global_mwpd.rst
+++ b/plugins/magnitudes/mwpd/descriptions/global_mwpd.rst
@@ -141,6 +141,18 @@ can be flattened per network without code changes using the standard
 :math:`M_w` proxies). Operators should derive these from a regression against
 their own reference magnitudes.
 
+Early-est itself is deliberately conservative with :math:`M_{wpd}` at smaller
+magnitudes: it is not reported/alerted below :math:`M_{wpd}\approx 7.0`
+(``alert.mwpd_min``, default 6.95) and is only set as the event's preferred
+magnitude once :math:`M_{wpd}\gtrsim 8.0` (``preferred.min_value.mwpd``; A.
+Lomax, pers. comm., 2026, suggests this could be lowered to approximately
+7.5). SeisComP's own preferred-magnitude selection (:ref:`scevent`) is a
+static per-type priority list rather than a value-gated threshold, so
+operators wanting equivalent behaviour should configure the :math:`M_{wpd}`
+priority accordingly: treat it with caution below :math:`M_w\approx 7` and
+avoid letting it override other magnitude types unless the event is
+confirmed large.
+
 Configuration
 =============
 


### PR DESCRIPTION
## Summary

Small documentation-only follow-up to #125.

During review of #125, Anthony Lomax (author of the original Mwpd method, Lomax & Michelini 2009) reached out by personal communication about the small low-magnitude bias discussed in that review. He noted that Early-est itself is deliberately conservative with Mwpd at smaller magnitudes:

- it does not report/alert Mwpd below Mwpd ≈ 7.0 (`alert.mwpd_min`, default 6.95)
- it only sets Mwpd as the event's preferred magnitude once Mwpd ≳ 8.0 (`preferred.min_value.mwpd`), and suggested this could reasonably be lowered to ~7.5

This was written up as a commit on the `feature/mwpd-magnitude` branch before #125 merged, but the commit was not pushed in time and missed the merge. This PR carries that same change forward against current `main`.

Adds a paragraph to `global_mwpd.rst` documenting the guidance, attributed to A. Lomax (pers. comm., 2026). SeisComP's own preferred-magnitude selection (`scevent`) is a static per-type priority list rather than a value-gated threshold, so this is operator guidance rather than a code change — no functional changes in this PR.

## Test plan

- [x] Docs-only change, no code touched
- [x] Cherry-picked cleanly onto current `main` post-#125 merge, `rst` builds without errors
